### PR TITLE
feat: add support for custom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ const server = fastify({
 });
 ```
 
+## Custom levels
+
+Custom levels could be used by passing it into logger opts
+
+```js
+const server = fastify({
+  logger: {
+    transport: {
+      target: "@fastify/one-line-logger",
+    },
+    customLevels: {
+      foo: 35,
+      bar: 45,
+    },
+  },
+});
+
+server.get("/", (request, reply) => {
+  request.log.info("time to foobar");
+  request.log.foo("FOO!");
+  request.log.bar("BAR!");
+  reply.send({ foobar: true });
+});
+```
+
 <a id="license"></a>
 ## License
 

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const pretty = require('pino-pretty')
 const messageFormatFactory = require('./lib/messageFormatFactory')
 
 const oneLineLogger = (opts = {}) => {
-  const { colorize, ...rest } = opts
+  const { colorize, levels, ...rest } = opts
 
-  const messageFormat = messageFormatFactory(colorize)
+  const messageFormat = messageFormatFactory(colorize, levels)
 
   return pretty({
     messageFormat,

--- a/lib/messageFormatFactory.js
+++ b/lib/messageFormatFactory.js
@@ -2,7 +2,7 @@
 const formatDate = require('./formatDate')
 const colorizerFactory = require('pino-pretty').colorizerFactory
 
-const messageFormatFactory = (colorize) => {
+const messageFormatFactory = (colorize, levels) => {
   const colorizer = colorizerFactory(colorize === true)
 
   const levelLookUp = {
@@ -12,6 +12,15 @@ const messageFormatFactory = (colorize) => {
     30: colorizer('info').toLowerCase(),
     20: colorizer('debug').toLowerCase(),
     10: colorizer('trace').toLowerCase()
+  }
+
+  const shouldAddCustomLevels = !!levels
+  if (shouldAddCustomLevels) {
+    Object.entries(levels).forEach(([name, level]) => {
+      const customLevels = { [level]: name }
+      const customLevelNames = { [name]: level }
+      levelLookUp[level] = colorizer(name, { customLevelNames, customLevels }).toLowerCase()
+    })
   }
 
   const colorizeMessage = colorizer.message

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,3 +78,38 @@ logDescriptorColorizedLogPairs.forEach(([logDescriptor, logColorized]) => {
     t.end()
   })
 })
+
+{
+  const levels = {
+    foo: 35,
+    bar: 45
+  }
+  const messageFormat = messageFormatFactory(false, levels)
+
+  const logCustomLevelsLogPairs = [
+    [
+      { time: EPOCH, level: 35, [MESSAGE_KEY]: 'basic foo log' },
+      `${TIME} - foo - basic foo log`
+    ],
+    [
+      {
+        time: EPOCH,
+        level: 45,
+        [MESSAGE_KEY]: 'basic incoming request bar log',
+        req: {
+          method: 'GET',
+          url: '/bar'
+        }
+      },
+      `${TIME} - bar - GET /bar - basic incoming request bar log`
+    ]
+  ]
+  logCustomLevelsLogPairs.forEach(([logDescriptor, expectedLog]) => {
+    test('format log correctly with custom levels', (t) => {
+      const log = messageFormat(logDescriptor, MESSAGE_KEY)
+
+      t.equal(log, expectedLog)
+      t.end()
+    })
+  })
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ declare namespace oneLineLogger {
     level: number;
     req?: Request;
   }
-  export const messageFormatFactory: (colorize: boolean) => (log: LogDescriptor, messageKey: string) => string
+  export const messageFormatFactory: (colorize: boolean, levels: Record<string, number>) => (log: LogDescriptor, messageKey: string) => string
 
   export const oneLineLogger: OneLineLogger
   export { oneLineLogger as default}

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -14,7 +14,7 @@ expectType<number>(({} as LogDescriptor).level)
 expectType<number>(({} as LogDescriptor).time)
 expectType<Request | undefined>(({} as LogDescriptor).req)
 
-expectType<(colorize: boolean) => (log: LogDescriptor, messageKey: string) => string>(messageFormatFactory)
+expectType<(colorize: boolean, levels: Record<string, number>) => (log: LogDescriptor, messageKey: string) => string>(messageFormatFactory)
 
 expectType<typeof oneLineLogger>(oneLineLoggerNamed)
 expectType<(opts?: pretty.PrettyOptions) => pretty.PrettyStream>(oneLineLogger)


### PR DESCRIPTION
feat(custom-levels): add levels to messageFormatFactory in order to handle pino customLevels

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
