### PR TITLE
perf(lib): replace redundant reduce call on array

### DIFF
--- a/benchmark/format-message.js
+++ b/benchmark/format-message.js
@@ -3,7 +3,15 @@
 const benchmark = require('benchmark')
 const messageFormatFactory = require('../lib/messageFormatFactory')
 
-const formatMessageColorized = messageFormatFactory(true)
+const colors = {
+  60: 'red',
+  50: 'red',
+  40: 'yellow',
+  30: 'green',
+  20: 'blue',
+  10: 'cyan'
+}
+const formatMessageColorized = messageFormatFactory(true, colors, true)
 const log = {
   time: Date.now(),
   level: 30,

--- a/lib/messageFormatFactory.js
+++ b/lib/messageFormatFactory.js
@@ -6,7 +6,8 @@ const messageFormatFactory = (levels, colors, useColors) => {
   const customColors =
     colors != null
       ? Object.entries(colors).reduce((colors, [level, color]) => {
-        return [...colors, [level, color]]
+        colors.push([level, color])
+        return colors
       }, [])
       : undefined
   const colorizer = colorizerFactory(useColors, customColors)

--- a/lib/messageFormatFactory.js
+++ b/lib/messageFormatFactory.js
@@ -5,10 +5,7 @@ const colorizerFactory = require('pino-pretty').colorizerFactory
 const messageFormatFactory = (levels, colors, useColors) => {
   let customColors
   if (colors !== null) {
-    customColors = []
-    for (const entry of Object.entries(colors)) {
-      customColors.push(entry)
-    }
+    customColors = Object.entries(colors)
   }
   const colorizer = colorizerFactory(useColors, customColors)
 

--- a/lib/messageFormatFactory.js
+++ b/lib/messageFormatFactory.js
@@ -3,13 +3,13 @@ const formatDate = require('./formatDate')
 const colorizerFactory = require('pino-pretty').colorizerFactory
 
 const messageFormatFactory = (levels, colors, useColors) => {
-  const customColors =
-    colors != null
-      ? Object.entries(colors).reduce((colors, [level, color]) => {
-        colors.push([level, color])
-        return colors
-      }, [])
-      : undefined
+  let customColors
+  if (colors !== null) {
+    customColors = []
+    for (const entry of Object.entries(colors)) {
+      customColors.push(entry)
+    }
+  }
   const colorizer = colorizerFactory(useColors, customColors)
 
   const levelLookUp = {

--- a/lib/messageFormatFactory.js
+++ b/lib/messageFormatFactory.js
@@ -4,7 +4,7 @@ const colorizerFactory = require('pino-pretty').colorizerFactory
 
 const messageFormatFactory = (levels, colors, useColors) => {
   let customColors
-  if (colors !== null) {
+  if (colors != null) {
     customColors = Object.entries(colors)
   }
   const colorizer = colorizerFactory(useColors, customColors)


### PR DESCRIPTION
Array of colors does not need to be reduced as the array returned by `Object.entries(colors)` is suitably structured anyway!

Benchmarks

Before:

`formatMessageColorized x 3,222,129 ops/sec ±0.74% (191 runs sampled)`

After:

`formatMessageColorized x 3,541,809 ops/sec ±0.56% (189 runs sampled)`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
