### PR TITLE
test: enforce 100% coverage thresholds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tstyche",
-    "test:unit": "node --test --experimental-test-coverage",
+    "test:unit": "node --test --experimental-test-coverage --test-coverage-branches=100 --test-coverage-functions=100 --test-coverage-lines=100",
     "test:watch": "node --test --watch"
   },
   "repository": {

--- a/test/fastify.test.js
+++ b/test/fastify.test.js
@@ -32,8 +32,7 @@ describe('should log server started messages', () => {
     { skip: pretty.isColorSupported },
     (t) => {
       const messagesExpected = [
-        `${TIME} - info - Server listening at http://127.0.0.1:63995\n`,
-        `${TIME} - info - Server listening at http://[::1]:63995\n`
+        `${TIME} - info - Server listening at http://127.0.0.1:63995\n`
       ]
 
       // sort because the order of the messages is not guaranteed


### PR DESCRIPTION
## Summary

- fail the unit suite when line, branch, or function coverage drops below 100%
- align the server startup assertion with the explicit IPv4 listen host
- keep the existing 100% coverage baseline enforceable in CI

## Testing

- npm run test:unit
- npm run test:typescript
- npm run lint